### PR TITLE
Fix typos in documentation

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -50,18 +50,18 @@ Here is the full list of commands, along with their defaults.
 | `left`              | move left                                          | d                    | h                    |
 | `right`             | move right                                         | n                    | l                    |
 | `toggle_playpause`  | toggles between play and pause                     | p                    | p                    |
-| `select`            | act on the selected entry                          | <enter>              | <enter>              |
+| `select`            | act on the selected entry                          | `<enter>`            | `<enter>`            |
 | `quit`              | close the program                                  | q                    | q                    |
 | `switch_to_library` | switch to library screen                           | 1                    | 1                    |
 | `switch_to_queue`   | switch to queue screen                             | 2                    | 2                    |
-| `toggle_screen_lq`  | toggle between library/queue                       | <tab>                | <tab>                |
+| `toggle_screen_lq`  | toggle between library/queue                       | `<tab>`              | `<tab>`              |
 | `toggle_panel`      | [library] switch between artist and track selector |                      |                      |
-| `fold`              | [library/track] toggle fold album                  | <space>              | <space>              |
+| `fold`              | [library/track] toggle fold album                  | `<space>`            | `<space>`            |
 | `clear_queue`       | clear queue                                        | -                    | -                    |
 | `local_search`      | search local selector                              | /                    | /                    |
 | `global_search`     | [library] global jumping search                    | g                    | C-g                  |
-| `escape`            | escape                                             | <esc>                | <esc>                |
-| `delete`            | [queue] deletes the selected item off queue        | <backspace>          | <backspace>          |
+| `escape`            | escape                                             | `<esc>`              | `<esc>`              |
+| `delete`            | [queue] deletes the selected item off queue        | `<backspace>`        | `<backspace>`        |
 | `toggle_repeat`     | toggle repeat                                      | r                    | r                    |
 | `toggle_single`     | toggle single                                      | s                    | s                    |
 | `toggle_consume`    | toggle consume                                     | c                    | c                    |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -20,21 +20,22 @@ command2 = "KEYSTR2"
 where a `"KEYSTR"` describes a keybinding with the following format that
 will be reminiscent to emacs users:
 
-    KEYSTR := <KEYBIND> <KEYSTR> | ""
-    KEYBIND := <MODIFIER><CHARACTER>
-    MODIFIER := C- | M- | S- | C-M- | ""
-    CHARACTER := char | <SPECIAL_KEY>
-    SPECIAL_KEY :=
-            | <space>
-            | <tab>
-            | <esc>
-            | <backspace>
-            | <delete>
-            | <up>
-            | <down>
-            | <left>
-            | <right>
-            | <enter>
+```
+KEYSTR := <KEYBIND> <KEYSTR> | ""
+KEYBIND := <MODIFIER><CHARACTER>
+MODIFIER := C- | M- | S- | C-M- | ""
+CHARACTER := char | <SPECIAL_KEY>
+SPECIAL_KEY := <space>
+  | <tab>
+  | <esc>
+  | <backspace>
+  | <delete>
+  | <up>
+  | <down>
+  | <left>
+  | <right>
+  | <enter>
+```
 
 Each of the modifiers corresponds to a modifier key, `CTRL, META,
 SUPER, CTRL+META`. So, your keybindings will look like `g g` or `C-c

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -5,13 +5,13 @@ defaulting to `$HOME/.config/inori/config.toml` if it is not set.
 
 ## Keybindings
 
-Keybindings set in the config file *override* the defaults if they are
+Keybindings set in the config file _override_ the defaults if they are
 set, but do not delete them.
 
 Keybindings should be defined in a toml table called `keybindings` like
 so:
 
-``` toml
+```toml
 [keybindings]
 command1 = "KEYSTR1"
 command2 = "KEYSTR2"
@@ -42,10 +42,8 @@ C-n` or `C-<space>`
 
 Here is the full list of commands, along with their defaults.
 
-
-
 | Command name        | Explanation                                        | Default key (dvorak) | Default key (qwerty) |
-|---------------------|----------------------------------------------------|----------------------|----------------------|
+| ------------------- | -------------------------------------------------- | -------------------- | -------------------- |
 | `up`                | move up                                            | t                    | k                    |
 | `down`              | move down                                          | h                    | j                    |
 | `left`              | move left                                          | d                    | h                    |
@@ -77,7 +75,7 @@ multiple keybinds.
 
 Colors should be specified in a table called "theme", like this:
 
-``` toml
+```toml
 [theme.item_to_color]
 fg = COLOR
 bg = COLOR
@@ -86,6 +84,7 @@ sub_modifier = MODIFIERS
 ```
 
 All fields are optional. `COLOR` should be **a string** of either
+
 - rgb hex: "#FF0000"
 - [ansi escape index](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit): "9"
 - ansi color code: "White", "Red", "LightCyan", etc
@@ -108,7 +107,7 @@ For example, you might write `add_modifier = "BOLD | ITALIC"`.
 Here is the full list of styles available for customization:
 
 | Name                      | Explanation                                    |
-|---------------------------|------------------------------------------------|
+| ------------------------- | ---------------------------------------------- |
 | `item_highlight_active`   | selected item in an active list                |
 | `item_highlight_inactive` | selected item in an inactive list              |
 | `block_active`            | active block border style                      |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ as a full list of all default keybindings.
 ![](./images/queue.png)
 
 ## Todo
+
 - [ ] Playlist interface
 - [ ] Compile feature flag for Japanese album/track title romanization for search using a tokenizer & dictionary
 - [ ] More thorough customization options, especially for behavior & layout tweaks


### PR DESCRIPTION
1. Run prettier
2. Fix grammar mistakes in the keybinding CFG
3. Prevent special keycodes like `<enter>` from being escaped.