### PR TITLE
Add support for unix socket

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -139,10 +139,8 @@ impl Model {
         let mut conn = if env::var("MPD_HOST").is_ok()
             && PathBuf::from(&mpd_host).exists()
         {
-            {
-                let client = Client::<UnixStream>::connect(&mpd_host)?;
-                Connection::UnixSocket(client)
-            }
+            let client = Client::<UnixStream>::connect(&mpd_host)?;
+            Connection::UnixSocket(client)
         } else {
             let client = Client::<TcpStream>::connect(&mpd_url)?;
             Connection::TcpSocket(client)
@@ -245,7 +243,7 @@ impl Model {
 }
 
 impl Connection {
-    fn status(&mut self) -> Result<Status> {
+    pub(crate) fn status(&mut self) -> Result<Status> {
         match self {
             #[cfg(unix)]
             Connection::UnixSocket(conn) => conn.status(),
@@ -253,7 +251,7 @@ impl Connection {
         }
     }
 
-    fn currentsong(&mut self) -> Result<Option<Song>> {
+    pub(crate) fn currentsong(&mut self) -> Result<Option<Song>> {
         match self {
             #[cfg(unix)]
             Connection::UnixSocket(conn) => conn.currentsong(),
@@ -261,7 +259,10 @@ impl Connection {
         }
     }
 
-    fn list_groups(&mut self, vec: Vec<&str>) -> Result<Vec<Vec<String>>> {
+    pub(crate) fn list_groups(
+        &mut self,
+        vec: Vec<&str>,
+    ) -> Result<Vec<Vec<String>>> {
         match self {
             #[cfg(unix)]
             Connection::UnixSocket(conn) => conn.list_groups(vec),

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,6 +7,7 @@ use ratatui::crossterm::event::KeyEvent;
 use ratatui::widgets::*;
 use std::env;
 use std::net::TcpStream;
+use std::time::Duration;
 mod impl_album_song;
 mod impl_artiststate;
 mod impl_library;
@@ -107,6 +108,7 @@ pub struct QueueSelector {
     pub state: TableState,
 }
 
+// thin wrapper around all supported ways to communicate with MPD
 pub enum Connection {
     #[cfg(unix)]
     UnixSocket(Client<UnixStream>),
@@ -381,6 +383,30 @@ impl Connection {
             #[cfg(unix)]
             Connection::UnixSocket(conn) => conn.toggle_pause(),
             Connection::TcpSocket(conn) => conn.toggle_pause(),
+        }
+    }
+
+    pub(crate) fn next(&mut self) -> Result<()> {
+        match self {
+            #[cfg(unix)]
+            Connection::UnixSocket(conn) => conn.next(),
+            Connection::TcpSocket(conn) => conn.next(),
+        }
+    }
+
+    pub(crate) fn prev(&mut self) -> Result<()> {
+        match self {
+            #[cfg(unix)]
+            Connection::UnixSocket(conn) => conn.prev(),
+            Connection::TcpSocket(conn) => conn.prev(),
+        }
+    }
+
+    pub(crate) fn seek(&mut self, place: u32, pos: Duration) -> Result<()> {
+        match self {
+            #[cfg(unix)]
+            Connection::UnixSocket(conn) => conn.seek(place, pos),
+            Connection::TcpSocket(conn) => conn.seek(place, pos),
         }
     }
 }


### PR DESCRIPTION
Hey there,

recently my MPD client of choice [ncmpcpp](https://github.com/ncmpcpp/ncmpcpp) went into maintenance mode, so I was looking for some alternatives. This project looks promising, and I can also contribute as I know some Rust. I am using Linux and configured MPD to use a unix socket file. I basically added a thin wrapper around the Client datastructure so that it can listen on that too, if applicable. I also checked these changes with Windows as a target, so this should not break anything.

On the library side, you would need to add a specialization on `UnixStream` as well. I implemented that too, do you want me to make a PR over there too?

Kind regards.