### PR TITLE
Add next, previous, and seek functionality

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -77,6 +77,10 @@ multiple keybinds.
 | `left`              | move left                                          | `<left>`      | d          | h          |
 | `right`             | move right                                         | `<right>`     | n          | l          |
 | `toggle_playpause`  | toggles between play and pause                     | p             |            |            |
+| `next song`         | jumps to the next song in the queue                |               |            |            |
+| `previous song`     | jumps to the previous song in the queue            |               |            |            |
+| `seek`              | seeks forward by 5 seconds                         |               |            |            |
+| `seek_backwards`    | seeks backwards by 5 seconds                       |               |            |            |
 | `select`            | act on the selected entry                          | `<enter>`     |            |            |
 | `quit`              | close the program                                  | q             |            |            |
 | `switch_to_library` | switch to library screen                           | 1             |            |            |
@@ -93,8 +97,8 @@ multiple keybinds.
 | `toggle_single`     | toggle single                                      | s             |            |            |
 | `toggle_consume`    | toggle consume                                     | c             |            |            |
 | `toggle_random`     | toggle random                                      | z             |            |            |
-| `top`               | jump to top                                        | `<home>`   | <          | g g        |
-| `bottom`            | jump to bottom                                     | `<end>` | >          | G          |
+| `top`               | jump to top                                        | `<home>`      | <          | g g        |
+| `bottom`            | jump to bottom                                     | `<end>`       | >          | G          |
 
 Note that the dvorak/qwerty sets *do not* delete the default
 keybindings.

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use keybind::{get_message, KeybindMap};
 pub struct Config {
     pub keybindings: KeybindMap,
     pub theme: Theme,
+    pub seek_seconds: i64,
 }
 
 impl Config {
@@ -19,6 +20,7 @@ impl Config {
         Config {
             keybindings: KeybindMap::default(),
             theme: Theme::new(),
+            seek_seconds: 5,
         }
     }
     pub fn try_read_config(mut self) -> Self {
@@ -31,6 +33,9 @@ impl Config {
             for (key, value) in toml {
                 match (key.as_str(), value) {
                     ("keybindings", Value::Table(t)) => self.read_keybinds(t),
+                    ("seek_seconds", Value::Integer(k)) if k > 0 => {
+                        self.seek_seconds = k
+                    }
                     ("theme", Value::Table(t)) => self.read_theme(t),
                     ("dvorak_keybindings", Value::Boolean(true)) => {
                         self.keybindings = self.keybindings.with_dvorak_style();

--- a/src/config/keybind.rs
+++ b/src/config/keybind.rs
@@ -39,6 +39,10 @@ pub fn get_message(s: &str) -> Option<Message> {
         "toggle_single" => Some(Message::Set(Toggle::Single)),
         "toggle_consume" => Some(Message::Set(Toggle::Consume)),
         "toggle_random" => Some(Message::Set(Toggle::Random)),
+        "next_song" => Some(Message::NextSong),
+        "previous_song" => Some(Message::PreviousSong),
+        "seek" => Some(Message::Seek(5)),
+        "seek_backwards" => Some(Message::Seek(-5)),
         _ => None,
     }
 }

--- a/src/config/keybind.rs
+++ b/src/config/keybind.rs
@@ -41,8 +41,8 @@ pub fn get_message(s: &str) -> Option<Message> {
         "toggle_random" => Some(Message::Set(Toggle::Random)),
         "next_song" => Some(Message::NextSong),
         "previous_song" => Some(Message::PreviousSong),
-        "seek" => Some(Message::Seek(5)),
-        "seek_backwards" => Some(Message::Seek(-5)),
+        "seek" => Some(Message::Seek(SeekDirection::Forward)),
+        "seek_backwards" => Some(Message::Seek(SeekDirection::Backward)),
         _ => None,
     }
 }


### PR DESCRIPTION
First of all, thanks for this cool MPD client. I love it very much, especially because it properly handles the sort fields which no other does. :)

I was noticing that a few functions were missing which I often use, namely skipping to the next and previous songs in the queue, and seeking forward and backwards. So I hacked them in myself and thought submitting them as a patch if you want them.

The changes mimic ncmpcpp's seek and skip behavior, because that's just what I'm used to. I.e. when you seek past the end of the song, it will skip to the next one, but seeking backwards will stop at 0:00 and not go back. Also, if consume is activated, then skipping forward will consume the current song, but skipping backwards does not. 