### PR TITLE
allow using arrays when defining keybindings

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -70,8 +70,9 @@ Each of the modifiers corresponds to a modifier key, `CTRL, META,
 SUPER, CTRL+META`. So, your keybindings will look like `g g` or `C-c
 C-n` or `C-<space>`
 
-Note that you can specify multiple entries for each command, creating
-multiple keybinds.
+You can create multiple keybinds for the same command by either
+creating multiple entries for it or by having one entry that is
+an array of `KEYSTR`.
 
 ### List of commands and defaults
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,9 +56,20 @@ impl Config {
                     let keybinds = keybind::parse_keybind(s)
                         .unwrap_or_else(|_| panic!("Couldn't parse keybinds"));
                     self.keybindings.insert(m.clone(), &keybinds);
-                }
+                },
+                (Some(m), Value::Array(a)) => {
+                    for s in a {
+                        if let Value::String(s) = s {
+                            let keybinds = keybind::parse_keybind(s)
+                                .unwrap_or_else(|_| panic!("Couldn't parse keybinds"));
+                            self.keybindings.insert(m.clone(), &keybinds);
+                        } else {
+                            panic!("keybind {} for command {} must be a string", s, key)
+                        }
+                    }
+                },
                 (Some(_), other) => panic!(
-                    "keybind {} for command {} must be a string",
+                    "keybind {} for command {} must be a string or an array",
                     other, key
                 ),
                 (None, _) => panic!("message {} does not exist", key),


### PR DESCRIPTION
this is needed because the current way is not toml compliant
i wouldnt care much about toml compliancy but i want to be able to generate the config through home-manager
tested, works flawlessly on my machine™