### PR TITLE
Stop long song progress status from getting truncated 

### DIFF
--- a/src/view/status_renderer.rs
+++ b/src/view/status_renderer.rs
@@ -78,7 +78,7 @@ pub fn render_status(
                 )),
             ]),
         ],
-        vec![Max(10), Min(10), Max(10)],
+        vec![Max(20), Min(10), Max(10)],
     )
     .block(Block::bordered().border_type(BorderType::Rounded));
     frame.render_widget(w, area);

--- a/src/view/status_renderer.rs
+++ b/src/view/status_renderer.rs
@@ -40,7 +40,7 @@ pub fn render_status(
                     .centered()
                     .set_style(theme.status_title),
                 ),
-                Cell::from("⎡r z s c⎤"),
+                Cell::from(Line::from("⎡r z s c⎤").right_aligned()),
             ]),
             Row::new(vec![
                 Cell::from(match model.status.state {
@@ -69,16 +69,19 @@ pub fn render_status(
                     }
                     .centered(),
                 ),
-                Cell::from(format!(
-                    "⎣{} {} {} {}⎦",
-                    format_status(model.status.repeat),
-                    format_status(model.status.random),
-                    format_status(model.status.single),
-                    format_status(model.status.consume)
-                )),
+                Cell::from(
+                    Line::from(format!(
+                        "⎣{} {} {} {}⎦",
+                        format_status(model.status.repeat),
+                        format_status(model.status.random),
+                        format_status(model.status.single),
+                        format_status(model.status.consume)
+                    ))
+                    .right_aligned(),
+                ),
             ]),
         ],
-        vec![Max(20), Min(10), Max(10)],
+        vec![Max(20), Min(10), Max(20)],
     )
     .block(Block::bordered().border_type(BorderType::Rounded));
     frame.render_widget(w, area);


### PR DESCRIPTION
Hi,

I noticed that the display on the left that shows "elapsed / duration" gets truncated for longer songs, which is pretty common for anything over 10 minutes:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/9d4db14e-4a60-4363-ab23-eadc578d6f88" />

I saw that this was constrained to 10, I bumped it up to 20 (kinda arbitrary, it'll only kick in if a song is thousands of hours long). Did the same for the cell on the right (and right aligned it) so that the middle cell would still stay centered.