### PR TITLE
Progress bar color cfg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,6 +127,12 @@ impl Config {
                 ("search_query_inactive", Value::Table(t)) => {
                     self.theme.search_query_inactive = deserialize_style(t);
                 }
+                ("progress_bar_filled", Value::Table(t)) => {
+                    self.theme.progress_bar_filled = deserialize_style(t)
+                }
+                ("progress_bar_unfilled", Value::Table(t)) => {
+                    self.theme.progress_bar_unfilled = deserialize_style(t)
+                }
                 (other, _) => panic!("theme option {} not found", other),
             }
         }

--- a/src/view.rs
+++ b/src/view.rs
@@ -25,6 +25,8 @@ pub struct Theme {
     pub slash_span: Style,
     pub search_query_active: Style,
     pub search_query_inactive: Style,
+    pub progress_bar_filled: Style,
+    pub progress_bar_unfilled: Style,
 }
 impl Theme {
     pub fn new() -> Self {
@@ -43,6 +45,12 @@ impl Theme {
             slash_span: Style::new().fg(LightMagenta),
             search_query_active: Style::new().bg(White).fg(Black),
             search_query_inactive: Style::new().bg(DarkGray).fg(Black),
+
+            progress_bar_filled: Style::default()
+                .fg(LightYellow)
+                .bg(Black)
+                .add_modifier(Modifier::BOLD),
+            progress_bar_unfilled: Style::default().fg(Black),
         }
     }
 }

--- a/src/view/queue_renderer.rs
+++ b/src/view/queue_renderer.rs
@@ -10,16 +10,11 @@ use std::time::Duration;
 
 use super::status_renderer::render_status;
 
-pub fn make_progress_bar<'a>(ratio: f64) -> LineGauge<'a> {
+pub fn make_progress_bar<'a>(ratio: f64, theme: &Theme) -> LineGauge<'a> {
     let progress_bar = LineGauge::default()
         .block(Block::bordered().title("Progress"))
-        .filled_style(
-            Style::default()
-                .fg(Color::LightYellow)
-                .bg(Color::Black)
-                .add_modifier(Modifier::BOLD),
-        )
-        .unfilled_style(Style::default().fg(Color::Black))
+        .filled_style(theme.progress_bar_filled)
+        .unfilled_style(theme.progress_bar_unfilled)
         .line_set(symbols::line::THICK)
         .ratio(ratio);
     progress_bar
@@ -110,5 +105,5 @@ pub fn render(model: &mut Model, frame: &mut Frame, theme: &Theme) {
         _ => 0 as f64,
     };
 
-    frame.render_widget(make_progress_bar(ratio), layout[2])
+    frame.render_widget(make_progress_bar(ratio, theme), layout[2])
 }


### PR DESCRIPTION
while I'm at it quickly shoved the progress bar into the config (the yellow didn't work well with the rest of my cfg visually). Might need some work still as I don't know the difference between `Style::default()` and `Style::new()` and the reason behind it.