### PR TITLE
Increase track duration area width

### DIFF
--- a/src/view/queue_renderer.rs
+++ b/src/view/queue_renderer.rs
@@ -56,7 +56,7 @@ pub fn make_queue<'a>(model: &mut Model, theme: &Theme) -> Table<'a> {
         .collect();
     let table = Table::new(
         rows,
-        vec![Percentage(50), Percentage(30), Percentage(20), Min(5)],
+        vec![Percentage(50), Percentage(30), Percentage(20), Min(7)],
     )
     .row_highlight_style(theme.item_highlight_active)
     .block(Block::bordered().title("Queue"));


### PR DESCRIPTION
Currently the track duration area width in the queue view is set to 5. This is not enough for rendering the duration of hour long tracks as shown in the screenshot below:

<img width="2161" height="129" alt="image" src="https://github.com/user-attachments/assets/43f55800-978e-4835-9847-68bd26e29157" />

I increased it to 7 which should be enough unless there are 10+ hour songs out there.